### PR TITLE
Fix displaying of images in Safari.

### DIFF
--- a/src/components/elements/Image.js
+++ b/src/components/elements/Image.js
@@ -51,10 +51,10 @@ const Image = ({
     placeholder.style.opacity = '0';
     img.className && placeholder.classList.add(img.className);
 
-    img.addEventListener('load', () => {
+    img.onload = () => {
       placeholder.remove();
       img.style.display = '';
-    });
+    };
   }  
 
   return (


### PR DESCRIPTION
Images were not displayed in Safari.
`img.addEventListener('load', ...)` was not triggered in Safari