### PR TITLE
Fix: event listeners

### DIFF
--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -41,7 +41,7 @@ const Header = ({
     document.addEventListener('click', clickOutside);
     return () => {
       document.removeEventListener('keydown', keyPress);
-      document.addEventListener('click', clickOutside);
+      document.removeEventListener('click', clickOutside);
       closeMenu();
     };
   });  


### PR DESCRIPTION
I am pretty sure it's a mistake and `removeEventListener` should be called on unmount, instead of rebinding the event.