### PR TITLE
Added support for Onduis Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,12 @@
 </head>
 
 <body class="has-animations">
+    
+    <!--- Added support for Onduis Analytics Seamless Tracking -->
+    
+    <script data-host="https://onduis.com" data-dnt="true" src="https://magic.onduis.com/js/script.js" id="ZwSg9rf6GA" async defer></script>
+    
+
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" class="body-wrap"></div>
 </body>


### PR DESCRIPTION
Added support for Onduis Analytics, users can create accounts on Onduis.com and after adding website, the tracker will work automatically